### PR TITLE
♻️ 补充测试，修复新订阅者没有收到新值

### DIFF
--- a/flow/src/state_flow.test.ts
+++ b/flow/src/state_flow.test.ts
@@ -1,0 +1,74 @@
+import { StateFlow } from "./state_flow.ts";
+import assert from "node:assert";
+
+// 测试构造函数初始值设置
+Deno.test("StateFlow - should initialize with correct value", () => {
+    const initialValue = 42;
+    const stateFlow = new StateFlow(initialValue);
+    assert.strictEqual(stateFlow.value, initialValue);
+});
+
+// 测试 value 的 getter 和 setter
+Deno.test("StateFlow - should update value through setter", () => {
+    const stateFlow = new StateFlow(1);
+    const newValue = 2;
+    stateFlow.value = newValue;
+    assert.strictEqual(stateFlow.value, newValue);
+});
+
+// 测试 emit 方法的状态变化
+Deno.test("StateFlow - should emit new value and update state", async () => {
+    const stateFlow = new StateFlow(0);
+    const newValue = 100;
+
+    // 创建一个监听器来验证 emit
+    let emittedValue: number | undefined;
+    stateFlow.on((value) => {
+        emittedValue = value;
+    });
+
+    await stateFlow.emit(newValue);
+
+    assert.strictEqual(stateFlow.value, newValue);
+    assert.strictEqual(emittedValue, newValue);
+});
+
+// 测试相同值的 emit 不会触发更新
+Deno.test("StateFlow - should not emit when value is the same", async () => {
+    const stateFlow = new StateFlow(1);
+    let emitCount = 0;
+
+    stateFlow.on(() => {
+        emitCount++;
+    });
+
+    await stateFlow.emit(1); // 相同的值
+    assert.strictEqual(emitCount, 0); // 不应该触发 emit
+
+    await stateFlow.emit(2); // 不同的值
+    assert.strictEqual(emitCount, 1); // 应该触发一次 emit
+});
+
+// 测试新订阅者是否立即收到当前状态
+Deno.test(
+    "StateFlow - should immediately emit current value to new subscribers",
+    () => {
+        const initialValue = 42;
+        const stateFlow = new StateFlow(initialValue);
+
+        let receivedValue: number | undefined;
+        stateFlow.watchImmediate((value) => {
+            receivedValue = value;
+        });
+
+        // 新订阅者应该立即收到当前值
+        assert.strictEqual(receivedValue, initialValue);
+
+        // 发送新值，新订阅者应该立即收到新值
+        stateFlow.emit(43);
+        stateFlow.on((value) => {
+            receivedValue = value;
+        });
+        assert.strictEqual(receivedValue, 43);
+    },
+);

--- a/flow/src/state_flow.ts
+++ b/flow/src/state_flow.ts
@@ -1,6 +1,10 @@
-import type { PureEvent } from "@gaubee/util/pure_event";
+import type { PureEvent, PureEventFun, PureEventListenOptions, PureEventOff } from "@gaubee/util/pure_event";
 import { SharedFlow } from "./shared_flow.ts";
 
+export type StateFlowListenOptions = PureEventListenOptions & {
+    /** 监听的时候，是否立即执行 */
+    immediate?: boolean;
+};
 /**
  * 带状态机的 SharedFlow
  */
@@ -15,6 +19,28 @@ export class StateFlow<T> extends SharedFlow<T> {
     }
     set value(value: T) {
         this.emit(value);
+    }
+    /**
+     * 附加监听
+     * 同 watch
+     * @deprecated 使用 watch
+     */
+    override on(cb: PureEventFun<T>, options?: StateFlowListenOptions): PureEventOff {
+        return this.watch(cb, options);
+    }
+    /**
+     * 附加监听
+     * 可以自定义唯一索引 key，如果重复，会移除之前的监听
+     */
+    override watch(cb: PureEventFun<T>, options?: StateFlowListenOptions): PureEventOff {
+        // 订阅时立即发送当前值
+        if (options?.immediate) {
+            cb(this.#value);
+        }
+        return super.watch(cb, options);
+    }
+    watchImmediate(cb: PureEventFun<T>, options?: PureEventListenOptions): PureEventOff {
+        return this.watch(cb, { ...options, immediate: true });
     }
     override emit(value: T): Promise<void> {
         if (this.#value !== value) {

--- a/util/src/abort.ts
+++ b/util/src/abort.ts
@@ -38,7 +38,7 @@ export const abort_signal_merge = (..._signals: (AbortSignal | undefined | null)
 
 const signal_promise_cache = new Map<AbortSignal, Promise<never>>();
 export const abort_signal_promisify = (
-    input: AbortSignal | { signal: AbortSignal }, /*AbortController*/
+    input: AbortSignal | /*AbortController*/ { signal: AbortSignal },
 ): Promise<never> => {
     const signal = input instanceof AbortSignal ? input : input.signal;
     return map_get_or_put(signal_promise_cache, signal, () => {

--- a/util/src/disposable.ts
+++ b/util/src/disposable.ts
@@ -1,5 +1,5 @@
 import { obj_assign_props } from "./object.ts";
-import { PureEvent, PureEventWithApply } from "./pure_event.ts";
+import { PureEvent, type PureEventWithApply } from "./pure_event.ts";
 
 // export class AsyncDisposable {
 //     readonly disposer = pureEvent<void>();
@@ -21,7 +21,7 @@ export class Disposable extends PureEvent<void> {
     }
 }
 
-export type DisposableWithApply = PureEventWithApply<void> & Disposable;
+export type DisposableWithApply = Disposable & PureEventWithApply<void>;
 export const disposable = (): DisposableWithApply => {
     const pe = new Disposable();
     const on = pe.on.bind(pe);

--- a/util/src/promise.ts
+++ b/util/src/promise.ts
@@ -1,7 +1,7 @@
 import { event_target_on } from "./event_target.ts";
 import { func_wrap } from "./func.ts";
-import { PureEvent } from "./index.ts";
-import { IterableItem } from "./iterable.ts";
+import type { PureEvent } from "./pure_event.ts";
+import type { IterableItem } from "./iterable.ts";
 import { map_get_or_put } from "./map.ts";
 
 /**

--- a/util/src/pure_event.ts
+++ b/util/src/pure_event.ts
@@ -1,6 +1,6 @@
 import { iter_map_async_try } from "./collections.ts";
 import type { Func } from "./func.ts";
-import { iter_map_not_null } from "./index.ts";
+import { iter_map_not_null } from "./iterable.ts";
 import { obj_assign_props, obj_delegate_by } from "./object.ts";
 import { promise_try } from "./promise.ts";
 
@@ -95,9 +95,17 @@ export class PureEvent<T> {
     }
     /**
      * 附加监听
-     * 可以自定义唯一索引 key，如果重复，会移除之前的监听
+     * 同 watch
+     * @deprecated 使用 watch
      */
     on(cb: PureEventFun<T>, options?: PureEventListenOptions): PureEventOff {
+        return this.watch(cb, options);
+    }
+    /**
+     * 附加监听
+     * 可以自定义唯一索引 key，如果重复，会移除之前的监听
+     */
+    watch(cb: PureEventFun<T>, options?: PureEventListenOptions): PureEventOff {
         const key = options?.key ?? cb;
         this.off(key);
 
@@ -113,11 +121,19 @@ export class PureEvent<T> {
 
     /**
      * 移除指定监听
+     * 同 unwatch
+     * @deprecated 使用 unwatch
+     */
+    off(key: unknown): PureEventOffResult {
+        return this.unwatch(key);
+    }
+    /**
+     * 移除指定监听
      * 如果没有指定事件，那么返回false
      * 否则，如果没有自定义 移除监听器（onDispose），那么直接返回true
      * 否则返回 PromiseSettledResult
      */
-    off(key: unknown): PureEventOffResult {
+    unwatch(key: unknown): PureEventOffResult {
         const event = this.events.get(key);
         if (event == null) {
             return false;
@@ -259,7 +275,7 @@ export class PureEvent<T> {
     }
 }
 
-export type PureEventWithApply<T> = PureEvent<T> & PureEvent<T>["on"];
+export type PureEventWithApply<T> = PureEvent<T> & PureEvent<T>["watch"];
 
 export const pureEvent = <T>(): PureEventWithApply<T> => {
     const pe = new PureEvent<T>();
@@ -291,7 +307,7 @@ export class PureEventDelegate<T> extends PureEvent<T> {
 }
 type PureEventDelegateWithApply<T> =
     & PureEventDelegate<T>
-    & PureEventDelegate<T>["on"];
+    & PureEventDelegate<T>["watch"];
 
 export const pureEventDelegate = <T>(): PureEventDelegateWithApply<T> => {
     const pe = new PureEventDelegate<T>();


### PR DESCRIPTION
1. `Disposable.ts` 好像是循环引用问题，未测试，暂时修改了一下。

```ts
./flow/src/state_flow.test.ts (uncaught error)
error: (in promise) ReferenceError: Cannot access 'PureEvent' before initialization
export class Disposable extends PureEvent<void> {
                                ^
    at file:///Users/waterbang/Desktop/waterbang/github/std/util/src/disposable.ts:12:33
```

2. 补充了 `state_flow`在on的时候，能马上拿到一个新值。 主要测试例子：`测试新订阅者是否立即收到当前状态`